### PR TITLE
Feature/bump airflow version

### DIFF
--- a/airflow_config/Dockerfile
+++ b/airflow_config/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow vars
-ARG AIRFLOW_VERSION=2.2.0
+ARG AIRFLOW_VERSION=2.2.1
 ARG AIRFLOW_USER_HOME=/usr/local/airflow
 ARG CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.8.txt"
 ARG AIRFLOW__CORE__LOAD_EXAMPLES=False

--- a/airflow_config/Dockerfile
+++ b/airflow_config/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow vars
-ARG AIRFLOW_VERSION=2.1.0
+ARG AIRFLOW_VERSION=2.2.0
 ARG AIRFLOW_USER_HOME=/usr/local/airflow
 ARG CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.8.txt"
 ARG AIRFLOW__CORE__LOAD_EXAMPLES=False


### PR DESCRIPTION
New version bump as 2.2.0 had a bug on migrations. If this deployment does not work we should revert to 2.1.0 and test again.