### PR TITLE
Added test to cascade operations

### DIFF
--- a/cornflow/models/dag.py
+++ b/cornflow/models/dag.py
@@ -18,6 +18,13 @@ class DeployedDAG(TraceAttributes):
     id = db.Column(db.String(128), primary_key=True)
     description = db.Column(TEXT, nullable=True)
 
+    dag_permissions = db.relationship(
+        "PermissionsDAG",
+        cascade="all,delete",
+        backref="deployed_dags",
+        primaryjoin="and_(DeployedDAG.id==PermissionsDAG.dag_id)",
+    )
+
     def __init__(self, data):
         super().__init__()
         self.id = data.get("id")

--- a/cornflow/models/user.py
+++ b/cornflow/models/user.py
@@ -60,6 +60,7 @@ class UserModel(TraceAttributes):
     )
 
     user_roles = db.relationship("UserRoleModel", cascade="all,delete", backref="users")
+
     dag_permissions = db.relationship(
         "PermissionsDAG",
         cascade="all,delete",

--- a/cornflow/tests/unit/test_dags.py
+++ b/cornflow/tests/unit/test_dags.py
@@ -120,6 +120,7 @@ class TestDagDetailEndpoint(TestExecutionsDetailEndpointMock):
         return
 
 
+# To test the permission deletion on cascade
 class TestDeployedDAGModel(TestCase):
     def create_app(self):
         app = create_app("testing")

--- a/cornflow/tests/unit/test_dags.py
+++ b/cornflow/tests/unit/test_dags.py
@@ -4,14 +4,24 @@ Unit test for the DAG endpoints
 
 # Import from libraries
 import json
+from flask_testing import TestCase
 
 # Import from internal modules
+from cornflow.app import create_app
+from cornflow.commands.access import access_init_command
+from cornflow.commands.dag import register_deployed_dags_command_test
+from cornflow.commands.permissions import register_dag_permissions_command
+from cornflow.shared.const import ADMIN_ROLE
+from cornflow.models import DeployedDAG, PermissionsDAG, UserModel, UserRoleModel
 from cornflow.shared.const import EXEC_STATE_CORRECT, EXEC_STATE_MANUAL
+from cornflow.shared.utils import db
 from cornflow.tests.const import (
+    CASE_PATH,
     DAG_URL,
     EXECUTION_URL_NORUN,
-    CASE_PATH,
     INSTANCE_URL,
+    SIGNUP_URL,
+    USER_URL,
 )
 from cornflow.tests.unit.test_executions import TestExecutionsDetailEndpointMock
 
@@ -108,3 +118,47 @@ class TestDagDetailEndpoint(TestExecutionsDetailEndpointMock):
         self.assertEqual(data["data"], instance_data["data"])
         self.assertEqual(data["config"], self.payload["config"])
         return
+
+
+class TestDeployedDAGModel(TestCase):
+    def create_app(self):
+        app = create_app("testing")
+        return app
+
+    def setUp(self):
+        db.create_all()
+        access_init_command(0)
+        register_deployed_dags_command_test(verbose=0)
+        self.url = USER_URL
+        self.model = UserModel
+        self.admin = dict(
+            username="anAdminUser", email="admin@admin.com", password="Testpassword1!"
+        )
+
+        response = self.client.post(
+            SIGNUP_URL,
+            data=json.dumps(self.admin),
+            follow_redirects=True,
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.admin["id"] = response.json["id"]
+
+        user_role = UserRoleModel({"user_id": self.admin["id"], "role_id": ADMIN_ROLE})
+        user_role.save()
+        db.session.commit()
+
+        register_dag_permissions_command(verbose=0)
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+
+    def test_permission_cascade_deletion(self):
+        before = PermissionsDAG.get_user_dag_permissions(self.admin["id"])
+        self.assertIsNotNone(before)
+        dag = DeployedDAG.query.get("solve_model_dag")
+        dag.delete()
+        after = PermissionsDAG.get_user_dag_permissions(self.admin["id"])
+        self.assertNotEqual(before, after)
+        self.assertGreater(len(before), len(after))

--- a/cornflow/tests/unit/test_dags.py
+++ b/cornflow/tests/unit/test_dags.py
@@ -120,7 +120,6 @@ class TestDagDetailEndpoint(TestExecutionsDetailEndpointMock):
         return
 
 
-# To test the permission deletion on cascade
 class TestDeployedDAGModel(TestCase):
     def create_app(self):
         app = create_app("testing")


### PR DESCRIPTION
Tested that cascade operations work properly for the PermissionsDAG model (both with users and deployed dags)